### PR TITLE
Added initialization of bNearWhite, added set method

### DIFF
--- a/src/ofxKinectCommonBridge.cpp
+++ b/src/ofxKinectCommonBridge.cpp
@@ -22,7 +22,8 @@ ofxKinectCommonBridge::ofxKinectCommonBridge(){
 	bVideoIsInfrared = false;
 	bInited = false;
 	bStarted = false;
-
+	bNearWhite = true;
+	
 	mappingColorToDepth = false;
 	mappingDepthToColor = false;
 
@@ -73,6 +74,11 @@ void ofxKinectCommonBridge::setDepthClipping(float nearClip, float farClip){
 	nearClipping = nearClip;
 	farClipping = farClip;
 	updateDepthLookupTable();
+}
+
+//---------------------------------------------------------------------------
+void ofxKinectCommonBridge::setNearWhite(bool nearWhite) {
+	bNearWhite = nearWhite;
 }
 
 //---------------------------------------------------------------------------

--- a/src/ofxKinectCommonBridge.h
+++ b/src/ofxKinectCommonBridge.h
@@ -72,6 +72,7 @@ class ofxKinectCommonBridge : protected ofThread {
 	bool initBodyIndexStream();
 
 	void setDepthClipping(float nearClip=500, float farClip=4000);
+	void setNearWhite(bool nearWhite);
 	
 	/// updates the pixel buffers and textures
 	///


### PR DESCRIPTION
Without initialization, the color scheme of depth pixels is randomly
defined on program start
